### PR TITLE
Allows vim-preview to work in OSX

### DIFF
--- a/autoload/preview.vim
+++ b/autoload/preview.vim
@@ -97,7 +97,7 @@ class Preview
       child = fork do
         grandchild = fork do
           [STDOUT, STDERR].each { |io| io.reopen("/dev/null", "w") }
-          exec [app, path].join(' ')
+          exec "#{app} #{Regexp.escape(path)}"
         end
         Process.detach grandchild
       end


### PR DESCRIPTION
Basically, Safari will not work if the extension is not html or some compatible extension.  Something about the mime style not matching up.  It ends up that Safari refers the file to Finder.  The other thing I did was not generate a completely temporary file.  This makes it so Safari will just reload the file after consecutive calls to preview, rather than opening a new tab each time.

Oh, I also make it so that if you want to list browsers with arguments you can do so.  The test for application existence is done by the first element of the command.  Basically, split the browser command on space and only check the first element.
