### PR TITLE
Pull fixes where filenames have spaces.

### DIFF
--- a/autoload/preview.vim
+++ b/autoload/preview.vim
@@ -91,10 +91,10 @@ class Preview
   # TODO: handle errors when app can't be opened
   def show_with(app_type, ext="html")
     path = tmp_write(ext, yield)
-    app = get_apps_by_type(app_type).find{|app| system("which #{app.split()[0]} 2>1 1> /dev/null")}
+    app = get_apps_by_type(app_type).find{|app| system("which #{app.split()[0]} >& /dev/null")}
     #puts path
     if app
-      fork{exec "#{app} #{Regexp.escape(path)} 2>1 1> /dev/null"}
+      fork{exec "#{app} #{Regexp.escape(path)} 2>&1 1>/dev/null"}
     else
       error "any of apllications you specified in #{OPTIONS[app_type_to_opt(app_type)]} are not available"
     end


### PR DESCRIPTION
I was having the problem where filenames with spaces would not be previewed properly because the spaces were not being escaped.  I don't know if I did this the correct way but I just added a call to Regexp.escape on the filename.
