### PR TITLE
RST Support

### DIFF
--- a/autoload/preview.vim
+++ b/autoload/preview.vim
@@ -2,7 +2,7 @@
 " File:        preview.vim
 " Description: Vim global plugin to preview markup files(markdown,rdoc,textile)
 " Author:      Sergey Potapov (aka Blake) <blake131313 AT gmail DOT com>
-" Version:     0.5
+" Version:     0.7
 " Homepage:    http://github.com/greyblake/vim-preview
 " License:     GPLv2+ -- look it up.
 " Copyright:   Copyright (C) 2010 Sergey Potapov (aka Blake)
@@ -59,7 +59,8 @@ class Preview
     :textile_ext  => "g:PreviewTextileExt",
     :rdoc_ext     => "g:PreviewRdocExt",
     :ronn_ext     => "g:PreviewRonnExt",
-    :html_ext     => "g:PreviewHtmlExt"
+    :html_ext     => "g:PreviewHtmlExt",
+    :rst_ext      => "g:PreviewRstExt"
   }
 
   DEPENDECIES = {
@@ -67,7 +68,8 @@ class Preview
     :markdown => {:gem => 'bluecloth'    , :require => 'bluecloth'      },
     :textile  => {:gem => 'RedCloth'     , :require => 'redcloth'       },
     :rdoc     => {:gem => 'github-markup', :require => 'github/markup'  },
-    :ronn     => {:gem => 'ronn'         , :require => 'ronn'           }
+    :ronn     => {:gem => 'ronn'         , :require => 'ronn'           },
+    :rst      => {:gem => 'RbST'         , :require => 'rbst'           }
   }
 
   def show
@@ -115,6 +117,13 @@ class Preview
     show_with(:browser) do
       tmp_file = Tempfile.new(@base_name + ".ronn"){|f| f.write(content)}
       wrap_html Ronn::Document.new(tmp_file.path).to_html
+    end
+  end
+
+  def show_rst
+    return unless load_dependencies(:rst)
+    show_with(:browser) do
+      wrap_html RbST.new(content).to_html
     end
   end
   
@@ -328,6 +337,13 @@ ruby << END_OF_RUBY
 END_OF_RUBY
 endfunction
 
+function! preview#show_html()
+call s:init()
+ruby << END_OF_RUBY
+    Preview.instance.show_html
+END_OF_RUBY
+endfunction
+
 function! preview#show_ronn()
 call s:init()
 ruby << END_OF_RUBY
@@ -335,9 +351,9 @@ ruby << END_OF_RUBY
 END_OF_RUBY
 endfunction
 
-function! preview#show_html()
+function! preview#show_rst()
 call s:init()
 ruby << END_OF_RUBY
-    Preview.instance.show_html
+    Preview.instance.show_rst
 END_OF_RUBY
 endfunction

--- a/doc/preview.txt
+++ b/doc/preview.txt
@@ -2,7 +2,7 @@
 
 Description: Vim global plugin to preview markup files(markdown,rdoc,textile)
 Author:      Sergey Potapov (aka Blake) <blake131313 AT gmail DOT com>
-Version:     0.5
+Version:     0.7
 Homepage:    http://github.com/greyblake/vim-preview
 License:     GPLv2+ -- look it up.
 Copyright:   Copyright (C) 2010 Sergey Potapov (aka Blake)
@@ -37,6 +37,7 @@ Copyright:   Copyright (C) 2010 Sergey Potapov (aka Blake)
 	5.5 PreviewRdocExt ................... |PreviewRdocExt|
 	5.6 PreviewHtmlExt ................... |PreviewHtmlExt|
         5.7 PreviewRonnExt ................... |PreviewRonnExt|
+        5.8 PreviewRstExt .................... |PreviewRstExt|
     6. Commands .............................. |PreviewCommands|
 	6.1 Preview .......................... |Preview|
 	6.2 PreviewMarkdown .................. |PreviewMarkdown|
@@ -44,6 +45,7 @@ Copyright:   Copyright (C) 2010 Sergey Potapov (aka Blake)
 	6.4 PreviewRdoc ...................... |PreviewRdoc|
 	6.5 PreviewHtml ...................... |PreviewHtml|
         6.6 PreviewRonn ...................... |PreviewRonn|
+        6.7 PreviewRst ....................... |PreviewRst|
     7. Mapping ............................... |PreviewMapping|
     8. Known Bugs ............................ |PreviewBugs|
     9. Credits ............................... |PreviewCredits|
@@ -66,6 +68,8 @@ The plugin supports the next formats:
     * rdoc                                 depends on 'github-markup' ruby gem
     * textile                              depends on 'RedCloth' ruby gem
     * ronn                                 depends on 'ronn' ruby gem
+    * reStructuredText(rst)                depends on 'RbSt' ruby gem and
+                                           rst2html util
     * html(htm)
 
 
@@ -81,6 +85,10 @@ If output is '1' the ruby interpreter is builtin.
 
 The second thing you should verify is that you have installed all necessary 
 ruby gems. Please see |PreviewFormats| section to find out what gems you need.
+
+For reStructuredText(rst) format except RbST ruby gem you also need rst2html.
+To get rst2html util you probably should install python-docutils package.
+Otherwise PreviewRst vim command will show empty html file.
 
 
 ==============================================================================
@@ -143,6 +151,13 @@ Default: html,htm
 Specifies file extensions separated by comma which should be handled as ronn.
 Default: ronn
 
+------------------------------------------------------------------------------
+5.8 g:PreviewRstExt                                           *PreviewRstExt*
+
+Specifies file extensions separated by comma which should be handled as
+reStructuredText.
+Default: rst
+
 
 ==============================================================================
 6. Commands                                                  *PreviewCommands*
@@ -182,6 +197,11 @@ Preview current file as html. File will be opened without any converting.
 
 Preview current file as ronn.
 
+------------------------------------------------------------------------------
+6.7 PreviewRst                                                    *PreviewRst*
+
+Preview current file as reStructuredText.
+
 
 ==============================================================================
 7. Mapping                                                    *PreviewMapping*
@@ -208,6 +228,7 @@ If you found other bugs please report it.  See |PreviewContact| for a contact.
 
     * Donald Ephraim Curtis - some support for OSX and Safari, fixing bugs
     * Sung Pae - fixing bugs
+    * Rdark - support for ronn file format
 
 
 ==============================================================================


### PR DESCRIPTION
I just performed a "git cherry-pick" of the commit 092842a406e9813571a7c23b7088bf1d4ca0a90a you have done to enable RST support in last version of the vim-preview.

I don't know why RST support was removed from vim-preview

Thanks for this wonderfull plugin

Sincerely

Bertrand Cachet

PS: I keep version to 0.7, maybe I should increment it ?
