### PR TITLE
Use non-recursive mapping

### DIFF
--- a/doc/preview.txt
+++ b/doc/preview.txt
@@ -217,13 +217,13 @@ Preview current file as reStructuredText.
 
 Default mapping to preview file is <Leader>P .
 You can easy map it to other keys. For example >
-    :nmap <Leader>p :Preview<CR>
+    :nnoremap <Leader>p :Preview<CR>
 <
 Also you can map some other commands which is not mapped by default. E.g. >
-    :nmap <Leader>Pm :PreviewMarkdown<CR>
-    :nmap <Leader>Pt :PreviewTextile<CR>
-    :nmap <Leader>Pr :PreviewRdoc<CR>
-    :nmap <Leader>Ph :PreviewHtml<CR>
+    :nnoremap <Leader>Pm :PreviewMarkdown<CR>
+    :nnoremap <Leader>Pt :PreviewTextile<CR>
+    :nnoremap <Leader>Pr :PreviewRdoc<CR>
+    :nnoremap <Leader>Ph :PreviewHtml<CR>
 <
 
 ==============================================================================

--- a/plugin/preview.vim
+++ b/plugin/preview.vim
@@ -90,4 +90,4 @@ command! PreviewRonn     call s:PreviewRonn()
 command! PreviewRst      call s:PreviewRst()
 
 " Default mapping
-:nmap <Leader>P :Preview<CR>
+:nnoremap <Leader>P :Preview<CR>


### PR DESCRIPTION
As a matter of good practice, I changed the mapping to be non-recursive (i.e., use `noremap` instead of `map`). Recursive maps are just a [bad idea](http://learnvimscriptthehardway.stevelosh.com/chapters/05.html#recursion).

This has no effect on the plugin's behavior, it just makes the code nicer.